### PR TITLE
Pypi support for Torchdyn

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     matplotlib
     torchvision
     scikit-learn
-    torchsde
 dependency_links = ['git+https://github.com/google-research/torchsde.git@master#egg=torchsde-0.1.1']
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     matplotlib
     torchvision
     scikit-learn
-    torchsde@git+https://github.com/google-research/torchsde#egg=torchsde-0.1.1
+    torchsde @ https://github.com/google-research/torchsde.git
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,8 @@ install_requires =
     matplotlib
     torchvision
     scikit-learn
-dependency_links = ['git+https://github.com/google-research/torchsde.git@master#egg=torchsde-0.1.1']
+    torchsde
+dependency_links = git+https://github.com/google-research/torchsde.git@master#egg=torchsde-0.1.1
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     matplotlib
     torchvision
     scikit-learn
-    torchsde @ https://github.com/google-research/torchsde.git
+    torchsde@git+https://github.com/google-research/torchsde#egg=torchsde-0.1.1
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description_content_type= text/markdown
 author = DiffEqML
 author_email = polimic03@gmail.com, massaroli@robot.t.u-tokyo.ac.jp
 url = https://github.com/DiffEqML/torchdyn
-version = 0.2.1
+version = 0.2.2
 license = Apache License, Version 2.0
 
 CLASSIFIERS =

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = torchdyn
 description = PyTorch package for all things neural differential equations.
 long_description = file: README.md
+long_description_content_type= text/markdown
 author = DiffEqML
 author_email = polimic03@gmail.com, massaroli@robot.t.u-tokyo.ac.jp
 url = https://github.com/DiffEqML/torchdyn

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,8 @@ install_requires =
     matplotlib
     torchvision
     scikit-learn
-    torchsde @ https://github.com/google-research/torchsde.git
+    torchsde
+dependency_links = ['git+https://github.com/google-research/torchsde.git@master#egg=torchsde-0.1.1']
 
 [options.extras_require]
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     matplotlib
     torchvision
     scikit-learn
-    torchsde
 dependency_links = git+https://github.com/google-research/torchsde.git@master#egg=torchsde-0.1.1
 
 [options.extras_require]


### PR DESCRIPTION
- Bump to 0.2.2
- Main PyPI Channel is clear for the upload. Check https://pypi.org/search/?q=torchdyn .
- Fixes issues seen in https://github.com/DiffEqML/torchdyn/runs/1089263482
- Hope the test and main password secrets are in line with convention.