### PR TITLE
[feat] adds new version of gal, fixed tutorial

### DIFF
--- a/test/test_neural_ode.py
+++ b/test/test_neural_ode.py
@@ -150,10 +150,10 @@ def test_vanilla_galerkin():
     trainloader = data.DataLoader(train, batch_size=len(X), shuffle=False)
 
     f = nn.Sequential(DepthCat(1),
-                      GalLinear(6, 64, expfunc=FourierExpansion),
+                      GalLinear(6, 64, expfunc=Fourier(5)),
                       nn.Tanh(),
                       DepthCat(1),
-                      GalLinear(64, 6, expfunc=PolyExpansion, n_eig=1))
+                      GalLinear(64, 6, expfunc=Polynomial(2)))
 
     model = nn.Sequential(Augmenter(augment_idx=1, augment_func=nn.Linear(2, 4)),
                           NeuralDE(f, solver='dopri5')
@@ -168,13 +168,12 @@ def test_vanilla_conv_galerkin():
     X = torch.randn(12, 1, 28, 28).to(device)
 
     f = nn.Sequential(DepthCat(1),
-                      GalConv2d(1, 12, kernel_size=3, padding=1, expfunc=FourierExpansion, n_harmonics=3),
+                      GalConv2d(1, 12, kernel_size=3, padding=1, expfunc=Fourier(3)),
                       nn.Tanh(),
                       DepthCat(1),
-                      GalConv2d(12, 1, kernel_size=3, padding=1, expfunc=FourierExpansion, n_harmonics=3))
+                      GalConv2d(12, 1, kernel_size=3, padding=1, expfunc=Fourier(3)))
 
-    model = nn.Sequential(NeuralDE(f, solver='dopri5')
-                          ).to(device)
+    model = nn.Sequential(NeuralDE(f, solver='dopri5')).to(device)
     model(X)
 
 def test_2nd_order():

--- a/test/test_neural_ode.py
+++ b/test/test_neural_ode.py
@@ -150,10 +150,10 @@ def test_vanilla_galerkin():
     trainloader = data.DataLoader(train, batch_size=len(X), shuffle=False)
 
     f = nn.Sequential(DepthCat(1),
-                      GalLinear(6, 64, expfunc=Fourier(5)),
+                      GalLinear(6, 64, basisfunc=Fourier(5)),
                       nn.Tanh(),
                       DepthCat(1),
-                      GalLinear(64, 6, expfunc=Polynomial(2)))
+                      GalLinear(64, 6, basisfunc=Polynomial(2)))
 
     model = nn.Sequential(Augmenter(augment_idx=1, augment_func=nn.Linear(2, 4)),
                           NeuralDE(f, solver='dopri5')
@@ -168,10 +168,10 @@ def test_vanilla_conv_galerkin():
     X = torch.randn(12, 1, 28, 28).to(device)
 
     f = nn.Sequential(DepthCat(1),
-                      GalConv2d(1, 12, kernel_size=3, padding=1, expfunc=Fourier(3)),
+                      GalConv2d(1, 12, kernel_size=3, padding=1, basisfunc=Fourier(3)),
                       nn.Tanh(),
                       DepthCat(1),
-                      GalConv2d(12, 1, kernel_size=3, padding=1, expfunc=Fourier(3)))
+                      GalConv2d(12, 1, kernel_size=3, padding=1, basisfunc=Fourier(3)))
 
     model = nn.Sequential(NeuralDE(f, solver='dopri5')).to(device)
     model(X)

--- a/torchdyn/models/__init__.py
+++ b/torchdyn/models/__init__.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .adadepth import *
 from .defunc import *
 from .energy import *
 from .galerkin import *

--- a/torchdyn/models/adadepth.py
+++ b/torchdyn/models/adadepth.py
@@ -1,0 +1,84 @@
+import torch
+import torch.nn as nn
+import torchdiffeq
+from .neuralde import NeuralODE
+
+def hook_backward_gradients(module, grad_input, grad_output):
+    module.grad_output = grad_output
+
+class HypernetDepth(nn.Module):
+    def __init__(self, g, baseline):
+        super().__init__()
+        self.g = g
+        self.baseline = baseline
+
+    def forward(self, x):
+        return torch.cat([torch.zeros(1).to(x), torch.abs(self.g(x) + 1)[0]])
+    
+    def grad(self, x):
+        fxS, dLdxS = self.fxS.mean(), self.grad_output[0].mean()
+        for p in self.g.parameters():
+            dSdp = torch.autograd.grad(torch.abs(self.g(x) + 1).mean(), p)[0]
+            with torch.no_grad():
+                if hasattr(p, 'grad'): p.grad += fxS * dLdxS * dSdp
+                else: p.grad = fxS * dLdxS * dSdp
+                
+#     def step(self):
+#         for i, p in enumerate(self.g.parameters()):
+#             p.add_(p.grad, alpha=-1e-3)
+            
+#     def zero_grad(self, x):
+#         for p in self.g.parameters(): p.grad.zero_()
+            
+    
+class AdaptiveDepthNeuralODE(NeuralODE):
+    """Adaptive-Depth Neural ODE
+
+    :param func: function parametrizing the vector field.
+    :type func: nn.Module
+    :param settings: specifies parameters of the Neural DE.
+    :type settings: dict
+    """
+    def __init__(self, func:nn.Module,
+                       order=1,
+                       sensitivity='autograd',
+                       s_span=torch.linspace(0, 1, 2),
+                       solver='rk4',
+                       atol=1e-4,
+                       rtol=1e-4,
+                       intloss=None,
+                       depthfunc=None):
+        super().__init__(func, order, sensitivity, s_span, solver, atol, rtol, intloss)
+
+        self.depthfunc = HypernetDepth(depthfunc, 2)
+        # pass self to depthfunc for hooks         
+        self.depthfunc.register_backward_hook(hook_backward_gradients)
+        
+    def _prep_odeint(self, x:torch.Tensor):
+        # determines s_span dynamically. Does not support different
+        # s_spans for different data samples (yet)
+        self.s_span = self.depthfunc(x)
+        self.S = self.s_span[-1]
+        return super()._prep_odeint(x)
+    
+    def forward(self, x:torch.Tensor):       
+        # hooks f(x(S)) for gradients
+        # TO DO: use hooks
+        out = super().forward(x); 
+        self.depthfunc.fxS = self.defunc( self.S, out)
+        return out
+    
+    def trajectory(self, x:torch.Tensor, s_span:torch.Tensor):
+        """Returns a data-flow trajectory at `s_span` points
+
+        :param x: input data
+        :type x: torch.Tensor
+        :param s_span: collections of points to evaluate the function at e.g torch.linspace(0, 1, 100) for a 100 point trajectory
+                       between 0 and 1
+        :type s_span: torch.Tensor
+        """
+        x = super()._prep_odeint(x)
+        sol = torchdiffeq.odeint(self.defunc, x, s_span,
+                                 rtol=self.rtol, atol=self.atol, method=self.solver)
+        return sol
+                

--- a/torchdyn/models/galerkin.py
+++ b/torchdyn/models/galerkin.py
@@ -14,82 +14,72 @@ import torch
 import torch.nn as nn
 
 
-def FourierExpansion(n_range, s):
-    """Fourier eigenbasis expansion
-    """
-    s_n_range = s*n_range
-    basis = [torch.cos(s_n_range), torch.sin(s_n_range)]
-    return basis
-
-def PolyExpansion(n_range, s):
-    """Polynomial expansion
-    """
-    basis = [s**n_range]
-    return basis
-
-# can be slimmed down with template class (sharing assign_weights and reset_parameters)
-class GalLinear(nn.Module):
-    """Linear Galerkin layer for depth--variant neural differential equations
+class GalLayer(nn.Module):
+    """Galerkin layer template. Introduced in https://arxiv.org/abs/2002.08071"""
+    def __init__(self, bias=True, expfunc=Fourier(5), dilation=True, shift=True):       
+        super().__init__()
+        self.dilation = torch.ones(1) if not dilation else nn.Parameter(data=torch.ones(1), requires_grad=True)
+        self.shift = torch.zeros(1) if not shift else nn.Parameter(data=torch.zeros(1), requires_grad=True)
+        self.expfunc = expfunc
+        self.n_eig = n_eig = self.expfunc.n_eig
+        self.deg = deg = self.expfunc.deg
+        
+    def reset_parameters(self):
+        torch.nn.init.zeros_(self.coeffs)
+        
+    def calculate_weights(self, s):
+        "Expands `s` following the chosen eigenbasis"
+        n_range = torch.linspace(0, self.deg, self.deg).to(self.coeffs.device)
+        basis = self.expfunc(n_range, s*self.dilation.to(self.coeffs.device) + self.shift.to(self.coeffs.device))
+        B = []  
+        for i in range(self.n_eig):
+            Bin = torch.eye(self.deg).to(self.coeffs.device)
+            Bin[range(self.deg), range(self.deg)] = basis[i]
+            B.append(Bin)
+        B = torch.cat(B, 1).to(self.coeffs.device)
+        coeffs = torch.cat([self.coeffs[:,:,i] for i in range(self.n_eig)],1).transpose(0,1).to(self.coeffs.device) 
+        X = torch.matmul(B, coeffs)
+        return X.sum(0)
+        
+class GalLinear(GalLayer):
+    """Linear Galerkin layer for depth--variant neural differential equations. Introduced in https://arxiv.org/abs/2002.08071
     :param in_features: input dimensions
     :type in_features: int
     :param out_features: output dimensions
     :type out_features: int
     :param bias: include bias parameter vector in the layer computation
     :type bias: bool
-    :param expfunc: {'FourierExpansion', 'PolyExpansion'}. Choice of eigenfunction expansion.
+    :param expfunc: {'Fourier', 'Polynomial', 'Chebychev', 'VanillaRBF', 'MultiquadRBF', 'GaussianRBF'}. Choice of eigenfunction expansion.
     :type expfunc: str
-    :param n_harmonics: number of elements of the truncated eigenfunction expansion.
-    :type n_harmonics: int
-    :param n_eig: number of distinct eigenfunctions in the basis
-    :type n_eig: int
     :param dilation: whether to optimize for `dilation` parameter. Allows the GalLayer to dilate the eigenfunction period.
     :type dilation: bool
     :param shift: whether to optimize for `shift` parameter. Allows the GalLayer to shift the eigenfunction period.
     :type shift: bool
     """
-    def __init__(self, in_features, out_features, bias=True, expfunc=FourierExpansion, n_harmonics=10, n_eig=2, dilation=True, shift=True):
-        super().__init__()
+    def __init__(self, in_features, out_features, bias=True, expfunc=Fourier(5), dilation=True, shift=True):       
+        super().__init__(bias, expfunc, dilation, shift)
+        
         self.in_features, self.out_features = in_features, out_features
-        self.dilation = torch.ones(1) if not dilation else nn.Parameter(data=torch.ones(1), requires_grad=True)
-        self.shift = torch.zeros(1) if not shift else nn.Parameter(data=torch.zeros(1), requires_grad=True)
-        self.expfunc = expfunc
-        self.n_eig = n_eig
-        self.n_harmonics = n_harmonics
         self.weight = torch.Tensor(out_features, in_features)
         if bias:
             self.bias = torch.Tensor(out_features)
         else:
-            self.register_parameter('bias', None)
-        self.coeffs = torch.nn.Parameter(torch.Tensor((in_features+1)*out_features, n_harmonics, n_eig))
-        self.reset_parameters()
-
-    def reset_parameters(self):
-        #torch.nn.init.uniform_(self.coeffs, 0, 1 / self.n_harmonics**6)
-        torch.nn.init.zeros_(self.coeffs)
-
-    def assign_weights(self, s):
-        n_range = torch.linspace(0, self.n_harmonics, self.n_harmonics).to(self.coeffs.device)
-        basis = self.expfunc(n_range, s*self.dilation.to(self.coeffs.device) + self.shift.to(self.coeffs.device))
-        B = []
-        for i in range(self.n_eig):
-            Bin = torch.eye(self.n_harmonics).to(self.coeffs.device)
-            Bin[range(self.n_harmonics), range(self.n_harmonics)] = basis[i]
-            B.append(Bin)
-        B = torch.cat(B, 1).to(self.coeffs.device)
-        coeffs = torch.cat([self.coeffs[:,:,i] for i in range(self.n_eig)],1).transpose(0,1).to(self.coeffs.device)
-        X = torch.matmul(B, coeffs)
-        return X.sum(0)
-
+            self.register_parameter('bias', None)         
+        self.coeffs = torch.nn.Parameter(torch.Tensor((in_features+1)*out_features, self.deg, self.n_eig))        
+        self.reset_parameters()  
+                
     def forward(self, input):
+        # For the moment, GalLayers rely on DepthCat to access the `s` variable. A better design would free the user
+        # of having to introduce DepthCat(1) every time a GalLayer is used
         s = input[-1,-1]
         input = input[:,:-1]
-        w = self.assign_weights(s)
+        w = self.calculate_weights(s)
         self.weight = w[0:self.in_features*self.out_features].reshape(self.out_features, self.in_features)
         self.bias = w[self.in_features*self.out_features:(self.in_features+1)*self.out_features].reshape(self.out_features)
         return torch.nn.functional.linear(input, self.weight, self.bias)
-
-class GalConv2d(nn.Module):
-    """2D convolutional Galerkin layer for depth--variant neural differential equations
+    
+class GalConv2d(GalLayer):
+    """2D convolutional Galerkin layer for depth--variant neural differential equations. Introduced in https://arxiv.org/abs/2002.08071
     :param in_channels: number of channels in the input image
     :type in_channels: int
     :param out_channels: number of channels produced by the convolution
@@ -102,59 +92,33 @@ class GalConv2d(nn.Module):
     :type padding: int
     :param bias: include bias parameter vector in the layer computation
     :type bias: bool
-    :param expfunc: {'FourierExpansion', 'PolyExpansion'}. Choice of eigenfunction expansion.
+    :param expfunc: {'Fourier', 'Polynomial', 'Chebychev', 'VanillaRBF', 'MultiquadRBF', 'GaussianRBF'}. Choice of eigenfunction expansion.
     :type expfunc: str
-    :param n_harmonics: number of elements of the truncated eigenfunction expansion.
-    :type n_harmonics: int
-    :param n_eig: number of distinct eigenfunctions in the basis
-    :type n_eig: int
     :param dilation: whether to optimize for `dilation` parameter. Allows the GalLayer to dilate the eigenfunction period.
     :type dilation: bool
     :param shift: whether to optimize for `shift` parameter. Allows the GalLayer to shift the eigenfunction period.
     :type shift: bool
     """
-    __constants__ = ['bias', 'in_channels', 'out_channels', 'kernel_size', 'stride', 'padding', 'n_harmonics']
+    __constants__ = ['bias', 'in_channels', 'out_channels', 'kernel_size', 'stride', 'padding', 'deg']
     def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=0, bias=True,
-                 expfunc=FourierExpansion, n_harmonics=10, n_eig=2, dilation=True, shift=True):
-        super().__init__()
-        self.in_channels, self.out_channels = in_channels, out_channels
-        self.dilation = torch.ones(1) if not dilation else nn.Parameter(data=torch.ones(1), requires_grad=True)
-        self.shift = torch.zeros(1) if not shift else nn.Parameter(data=torch.zeros(1), requires_grad=True)
-        self.pad = padding
-        self.stride = stride
-        self.expfunc = expfunc
-        self.n_eig = n_eig
-        self.n_harmonics = n_harmonics
+                 expfunc=Fourier(5), dilation=True, shift=True):     
+        super().__init__(bias, expfunc, dilation, shift)
+        
+        self.ic, self.oc, self.ks = in_channels, out_channels, kernel_size
+        self.pad, self.stride = padding, stride
+
         self.weight = torch.Tensor(out_channels, in_channels, kernel_size, kernel_size)
         if bias:
             self.bias = torch.Tensor(out_channels)
         else:
             self.register_parameter('bias', None)
-        self.coeffs = torch.nn.Parameter(torch.Tensor(((out_channels)*in_channels*(kernel_size**2)+out_channels), n_harmonics, 2))
+        self.coeffs = torch.nn.Parameter(torch.Tensor(((out_channels)*in_channels*(kernel_size**2)+out_channels), self.deg, 2))
         self.reset_parameters()
-        self.ic, self.oc, self.ks, self.nh = in_channels, out_channels, kernel_size, n_harmonics
-
-    def reset_parameters(self):
-        #torch.nn.init.uniform_(self.coeffs, 0, 1 / self.n_harmonics**6)
-        torch.nn.init.zeros_(self.coeffs)
-
-    def assign_weights(self, s):
-        n_range = torch.linspace(0, self.n_harmonics, self.n_harmonics).to(self.coeffs.device)
-        basis = self.expfunc(n_range, s*self.dilation.to(self.coeffs.device) + self.shift.to(self.coeffs.device))
-        B = []
-        for i in range(self.n_eig):
-            Bin = torch.eye(self.n_harmonics).to(self.coeffs.device)
-            Bin[range(self.n_harmonics), range(self.n_harmonics)] = basis[i]
-            B.append(Bin)
-        B = torch.cat(B, 1).to(self.coeffs.device)
-        coeffs = torch.cat([self.coeffs[:,:,i] for i in range(self.n_eig)],1).transpose(0,1).to(self.coeffs.device)
-        X = torch.matmul(B, coeffs)
-        return X.sum(0)
-
+        
     def forward(self, input):
         s = input[-1,-1,0,0]
         input = input[:,:-1]
-        w = self.assign_weights(s)
+        w = self.calculate_weights(s)
         n = self.oc*self.ic*self.ks*self.ks
         self.weight = w[0:n].reshape(self.oc, self.ic, self.ks, self.ks)
         self.bias = w[n:].reshape(self.oc)

--- a/torchdyn/models/galerkin.py
+++ b/torchdyn/models/galerkin.py
@@ -12,6 +12,138 @@
 
 import torch
 import torch.nn as nn
+import numpy as np
+
+class GaussianRBF(nn.Module):
+    """Eigenbasis expansion using gaussian radial basis functions. $phi(r) = e^{-(\eps r)^2}$ with $r := || x - x0 ||_2$"
+    :param deg: degree of the eigenbasis expansion
+    :type deg: int
+    :param adaptive: whether to adjust `centers` and `eps_scales` during training.
+    :type adaptive: bool
+    :param eps_scales: scaling in the rbf formula ($\eps$)
+    :type eps_scales: int
+    :param centers: centers of the radial basis functions (one per degree). Same center across all degrees. x0 in the radius formulas
+    :type centers: int
+    """
+    def __init__(self, deg, adaptive=False, eps_scales=2, centers=0):
+        super().__init__()
+        self.deg, self.n_eig = deg, 1
+        if adaptive:
+            self.centers = torch.nn.Parameter(centers*torch.ones(deg+1))
+            self.eps_scales = torch.nn.Parameter(eps_scales*torch.ones((deg+1)))
+        else:
+            self.centers = 0; self.eps_scales = 2
+                                               
+    def forward(self, n_range, s):
+        n_range_scaled = (n_range - self.centers) / self.eps_scales
+        r = torch.norm(s - self.centers, p=2)
+        basis = [math.e**(-(r*n_range_scaled)**2)]
+        return basis
+    
+class VanillaRBF(nn.Module):
+    """Eigenbasis expansion using vanilla radial basis functions."
+    :param deg: degree of the eigenbasis expansion
+    :type deg: int
+    :param adaptive: whether to adjust `centers` and `eps_scales` during training.
+    :type adaptive: bool
+    :param eps_scales: scaling in the rbf formula ($\eps$)
+    :type eps_scales: int
+    :param centers: centers of the radial basis functions (one per degree). Same center across all degrees. x0 in the radius formulas
+    :type centers: int
+    """
+    def __init__(self, deg, adaptive=False, eps_scales=2, centers=0):
+        super().__init__()
+        self.deg, self.n_eig = deg, 1
+        if adaptive:
+            self.centers = torch.nn.Parameter(centers*torch.ones(deg+1))
+            self.eps_scales = torch.nn.Parameter(eps_scales*torch.ones((deg+1)))
+        else:
+            self.centers = 0; self.eps_scales = 2
+                                               
+    def forward(self, n_range, s):
+        n_range_scaled = n_range / self.eps_scales
+        r = torch.norm(s - self.centers, p=2)
+        basis = [r*n_range_scaled]
+        return basis
+    
+class MultiquadRBF(nn.Module):
+    """Eigenbasis expansion using multiquadratic radial basis functions."
+    :param deg: degree of the eigenbasis expansion
+    :type deg: int
+    :param adaptive: whether to adjust `centers` and `eps_scales` during training.
+    :type adaptive: bool
+    :param eps_scales: scaling in the rbf formula ($\eps$)
+    :type eps_scales: int
+    :param centers: centers of the radial basis functions (one per degree). Same center across all degrees. x0 in the radius formulas
+    :type centers: int
+    """
+    def __init__(self, deg, adaptive=False, eps_scales=2, centers=0):
+        super().__init__()
+        self.deg, self.n_eig = deg, 1
+        if adaptive:
+            self.centers = torch.nn.Parameter(centers*torch.ones(deg+1))
+            self.eps_scales = torch.nn.Parameter(eps_scales*torch.ones((deg+1)))
+        else:
+            self.centers = 0; self.eps_scales = 2
+                                               
+    def forward(self, n_range, s):
+        n_range_scaled = n_range / self.eps_scales
+        r = torch.norm(s - self.centers, p=2)
+        basis = [1 + torch.sqrt(1+ (r*n_range_scaled)**2)]
+        return basis
+    
+class Fourier(nn.Module):
+    """Eigenbasis expansion using fourier functions."
+    :param deg: degree of the eigenbasis expansion
+    :type deg: int
+    :param adaptive: does nothing (for now)
+    :type adaptive: bool
+    """
+    def __init__(self, deg, adaptive=False):
+        super().__init__()
+        self.deg, self.n_eig = deg, 2
+                                               
+    def forward(self, n_range, s):
+        s_n_range = s*n_range
+        basis = [torch.cos(s_n_range), torch.sin(s_n_range)]
+        return basis
+    
+class Polynomial(nn.Module):
+    """Eigenbasis expansion using polynomials."
+    :param deg: degree of the eigenbasis expansion
+    :type deg: int
+    :param adaptive: does nothing (for now)
+    :type adaptive: bool
+    """
+    def __init__(self, deg, adaptive=False):
+        super().__init__()
+        self.deg, self.n_eig = deg, 1
+                                               
+    def forward(self, n_range, s):
+        basis = [s**n_range]
+        return basis
+    
+class Chebychev(nn.Module):
+    """Eigenbasis expansion using chebychev polynomials."
+    :param deg: degree of the eigenbasis expansion
+    :type deg: int
+    :param adaptive: does nothing (for now)
+    :type adaptive: bool
+    """
+    def __init__(self, deg, adaptive=False):
+        super().__init__()
+        self.deg, self.n_eig = deg, 1
+                                               
+    def forward(self, n_range, s):
+        max_order = n_range[-1].int().item()
+        basis = [1]
+        # Based on numpy's Cheb code
+        if max_order > 0:
+            s2 = 2*s
+            basis += [s.item()]
+            for i in range(2, max_order):
+                basis += [basis[-1]*s2 - basis[-2]]
+        return [torch.tensor(basis).to(n_range)]
 
 
 class GalLayer(nn.Module):

--- a/torchdyn/sensitivity/adjoint.py
+++ b/torchdyn/sensitivity/adjoint.py
@@ -1,3 +1,125 @@
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #      http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
+# """
+# Adjoint template and variations of the adjoint technique
+# """
+
+# import torch
+# import torch.nn as nn
+# from torchdiffeq import odeint
+
+
+# def flatten(iterable):
+#     return torch.cat([el.contiguous().flatten() for el in iterable])
+
+# class ODEAdjointFunc:
+#     """ Define the vector field of the augmented adjoint dynamics to be then integrated **backward**. An `Adjoint` object is istantiated into the `NeuralDE` if the adjoint method for back-propagation was selected.
+#     :param s: current depth
+#     :type s: float
+#     :param adjoint_state: tuple of four tensors constituting the *augmented adjoint state* to be integrated: `h` (hidden state of the neural ODE), `λ` (Lagrange multiplier), `μ` (loss gradient state), `s_adj` (adjoint state of the integration depth)
+#     :type adjoint_state: tuple of tensors
+#     """
+#     def __init__(self, f, g=None):
+#         self.f, self.g = f, g
+
+#     def solve_forward(self, s, z):
+#         return self.f(s, z)
+
+#     def solve_backward(self, s, adjoint_state):
+#         z, λ, μ, s_adj = adjoint_state[0:4]
+        
+#         # temporarily removed
+#         with torch.set_grad_enabled(True):
+#             z = z.requires_grad_(True)
+#             s = s.requires_grad_(True) 
+            
+#             dzds = self.f(s, z)
+#             dλds = torch.autograd.grad(dzds, z, -λ, allow_unused=True, retain_graph=True)[0]
+#             dμds = torch.autograd.grad(dzds, tuple(self.f_params), -λ, allow_unused=True, retain_graph=True)
+#             if not self.g is None:
+#                 dgdh = torch.autograd.grad(self.g(s, z).sum(), z, allow_unused=True, retain_graph=True)[0]
+#                 dλds = dλds - dgdh
+                
+#             #ds_adjds = torch.autograd.grad(dzds, s, -λ, allow_unused=True, retain_graph=True)[0]
+#             #if ds_adjds is None: ds_adjds = torch.zeros_like(s)
+#             ds_adjds = torch.zeros_like(s)
+                
+#             # Safety checks for `None` gradients
+#             dμds = torch.cat([el.flatten() if el is not None else torch.zeros_like(p) for el, p in zip(dμds, self.f_params)]).to(z)
+#         return (dzds, dλds, dμds, ds_adjds)
+    
+
+# class Adjoint(nn.Module):
+#     """Adjoint class template.
+#     :param intloss: `nn.Module` specifying the integral loss term
+#     :type intloss: nn.Module
+#     """
+#     def __init__(self, f, g=None):
+#         super().__init__()
+#         self._adjoint_func = ODEAdjointFunc(f, g)
+
+#     def _init_adjoint_state(self, sol, *grad_output):
+#         λ0 = grad_output[-1][0]
+#         s_adj0 = torch.tensor(0.).to(λ0)
+#         #s_adj0 = λ0 * sol[-1]
+#         μ0 = torch.zeros_like(flatten(self._adjoint_func.f_params))
+#         return (sol[-1], λ0, μ0, s_adj0)
+
+#     def _wrap_func_autograd(self, s_span, rtol, atol, method, options):
+#         class autograd_adjoint(torch.autograd.Function):
+#             @staticmethod
+#             def forward(ctx, h0, flat_params, s_span):
+#                 sol = odeint(self._adjoint_func.solve_forward, h0, s_span, rtol=rtol, atol=atol,
+#                              method=method, options=options)
+#                 ctx.save_for_backward(s_span, sol)
+#                 return sol[-1]
+
+#             @staticmethod
+#             def backward(ctx, *grad_output):
+#                 s, sol = ctx.saved_tensors
+#                 adj0 = self._init_adjoint_state(sol, grad_output)
+#                 adj_sol = odeint(self._adjoint_func.solve_backward, adj0, s_span.flip(0),
+#                                rtol=rtol, atol=atol, method=method, options=options)
+#                 λ = adj_sol[0]
+#                 μ = adj_sol[1]
+#                 # does not currently support batched s_spans
+#                 # temporary fix for adaptive-depth gradients: mean  
+#                 return (λ, μ, None)
+#         return autograd_adjoint
+
+    
+#     def forward(self, func, h0, s_span, rtol=1e-4, atol=1e-4, method='dopri5', options={}):
+#         if not isinstance(func, nn.Module):
+#             raise ValueError('func is required to be an instance of nn.Module.')
+#         h0 = h0.requires_grad_(True)
+#         self._adjoint_func.f_params = find_f_params(func)
+#         flat_params = flatten(self._adjoint_func.f_params)
+#         self._wrapped_adjoint_func = self._wrap_func_autograd(s_span, rtol, atol, method, options)
+#         sol = self._wrapped_adjoint_func.apply(h0, flat_params, s_span)
+#         return sol
+
+
+# def find_f_params(module):
+#     assert isinstance(module, nn.Module)
+#     if getattr(module, '_is_replica', False):
+#         def find_tensor_attributes(module):
+#             tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v) and v.requires_grad]
+#             return tuples
+#         gen = module._named_members(get_members_fn=find_tensor_attributes)
+#         return [param for _, param in gen]
+#     else:
+#         return list(module.parameters())
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tutorials/01_neural_ode_cookbook.ipynb
+++ b/tutorials/01_neural_ode_cookbook.ipynb
@@ -559,7 +559,7 @@
     "# vector field parametrized by a NN with \"GalLinear\" layer\n",
     "# notice how DepthCat is still used since Galerkin layers make use of `s` (though in a different way compared to concatenation)\n",
     "f = nn.Sequential(DepthCat(1), \n",
-    "                  GalLinear(2, 32, expfunc=Fourier(5)),\n",
+    "                  GalLinear(2, 32, basisfunc=Fourier(5)),\n",
     "                  nn.Tanh(),\n",
     "                  nn.Linear(32, 2))\n",
     "# neural ODE\n",

--- a/tutorials/01_neural_ode_cookbook.ipynb
+++ b/tutorials/01_neural_ode_cookbook.ipynb
@@ -559,7 +559,7 @@
     "# vector field parametrized by a NN with \"GalLinear\" layer\n",
     "# notice how DepthCat is still used since Galerkin layers make use of `s` (though in a different way compared to concatenation)\n",
     "f = nn.Sequential(DepthCat(1), \n",
-    "                  GalLinear(2, 32, expfunc=FourierExpansion, n_harmonics=5),\n",
+    "                  GalLinear(2, 32, expfunc=Fourier(5)),\n",
     "                  nn.Tanh(),\n",
     "                  nn.Linear(32, 2))\n",
     "# neural ODE\n",


### PR DESCRIPTION
Summary of changes:

**Major**

- [x] New `GalLayer` template. Improves code reuse across `GalLinear` and `GalConv2d`. 

- [x] Several new eigenbasis expansion choices for `GalLayers`. 

- [x] `GalLayers` now takes `expfunc` and `expfunc` has a call signature `expfunc(deg)`. `n_eig` moved as implicit property of each eigenbasis expansion (not settable from outside anymore)

**Minor**

- [x] Adapted Gal tests to new API

- [x] Adapted `cookbook` to new API

TO DOs before merge: adapt `05_integral_loss` to new API