### PR TITLE
Update Quick Start Example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Neural differential equations made easy:
 ```
-from torchdyn import NeuralODE
+from torchdyn.core import NeuralODE
 
 # your preferred torch.nn.Module here 
 f = nn.Sequential(nn.Conv2d(1, 32, 3),


### PR DESCRIPTION
I guess NeuralODE was moved from torchdyn namespace to torchdyn.core namespace at some point. The current example on Quick Start thus returns en error.