### PR TITLE
adding requirements file for pytorch lightning ci

### DIFF
--- a/.github/workflows/os-coverage.yml
+++ b/.github/workflows/os-coverage.yml
@@ -34,7 +34,10 @@ jobs:
         poetry lock
         poetry build
         poetry install
-        
+        poetry run pip install 'setuptools==59.5.0'
+      # pinning setuptools is a temporary fix to: pytorch-lightning 1.5.10 requires setuptools==59.5.0
+      # supposedly poetry allows pinning ver. of setuptools in pyproject.ml files but it is not working atm https://github.com/python-poetry/poetry/issues/4511
+              
     - name: Run tests
       run: |
         source $HOME/.poetry/env

--- a/.github/workflows/validate-tutorials.yml
+++ b/.github/workflows/validate-tutorials.yml
@@ -34,7 +34,9 @@ jobs:
         poetry lock
         poetry build
         poetry install 
-        
+        poetry run pip install 'setuptools==59.5.0'
+      # pinning setuptools is a temporary fix to: pytorch-lightning 1.5.10 requires setuptools==59.5.0
+      # supposedly poetry allows pinning ver. of setuptools in pyproject.ml files but it is not working atm https://github.com/python-poetry/poetry/issues/4511
     - name: Validate all notebook tutorials
       run: |
         source $HOME/.poetry/env

--- a/.github/workflows/validate-tutorials.yml
+++ b/.github/workflows/validate-tutorials.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 15
 
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
+        os: [ubuntu-18.04]
         python-version: [3.8, 3.9]
         exclude:
           # temporary exclusion until py3.8 deps work on Windows

--- a/pl-ci-reqs.txt
+++ b/pl-ci-reqs.txt
@@ -1,0 +1,5 @@
+torch
+pytorch_lightning
+scipy
+scikit-learn
+torchcde

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "torchdyn"
 version = "1.0.1"
 license = "Apache License, Version 2.0"
-description = "Your PyTorch package for neural differential equations"
-authors = ["Michael Poli", "Stefano Massaroli", ]
+description = "A PyTorch library entirely dedicated to neural differential equations, implicit models and related numerical methods."
+authors = ["Michael Poli", "Stefano Massaroli", "DiffEqML"]
 packages = [
     {include = "torchdyn"}
 ]
@@ -30,7 +30,7 @@ poethepoet = "^0.10.0"
 dgl = "*"
 
 [tool.poe.tasks]
-force-cuda11 = "python -m pip install torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio===0.9.0 -f https://download.pytorch.org/whl/torch_stable.html"
+force-cuda11 = "python -m pip install torch==1.10.0+cu111 torchvision torchaudio -f https://download.pytorch.org/whl/torch_stable.html"
 
 [build-system]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
fixes https://github.com/DiffEqML/torchdyn/issues/126#issue-1113606680


`test_energy.py` call PyTorch Lightning directly and we will use these to get started with the PyTorch Lightning CI here https://github.com/DiffEqML/ecosystem-ci/tree/main .

We need a requirements file to be able to integrate with their request. See the link above for more details. 

