### PR TITLE
bugfixes for args in steps

### DIFF
--- a/test/models/test_ode.py
+++ b/test/models/test_ode.py
@@ -78,9 +78,9 @@ def test_save(moons_trainloader, small_mlp, testlearner, device):
 
 # TODO: extend to GPU and Multi-GPU
 @pytest.mark.parametrize('device', devices)
-def test_dict_out(moons_trainloader, small_mlp, testlearner, device):
+def test_dict_out_and_args(moons_trainloader, small_mlp, testlearner, device):
 
-    def fun(t, x):
+    def fun(t, x, args):
         inps = torch.cat([x["i1"], x["i2"]], dim=-1)
         outs = small_mlp(inps)
         return t, {"i1": outs[..., 0:1], "i2": outs[..., 1:2]}
@@ -90,7 +90,7 @@ def test_dict_out(moons_trainloader, small_mlp, testlearner, device):
             super(DummyIntegrator, self).__init__()
 
         def step(self, f, x, t, dt, k1=None, args=None):
-            _, x_sol = f(t, x)
+            _, x_sol = f(t, x, args)
             return None, x_sol, None
 
     x0 = {"i1": torch.rand(1, 1), "i2": torch.rand(1, 1)}
@@ -244,7 +244,7 @@ def test_arg_ode():
         def __init__(self, l):
             super().__init__()
             self.l = l
-        def forward(self, t, x, u, v, z):
+        def forward(self, t, x, u, v, z, args={}):
             return self.l(x + u + v + z)
 
     tfunc = TFunc(l)

--- a/torchdyn/core/defunc.py
+++ b/torchdyn/core/defunc.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+from typing import Callable, Dict
 import torch
 from torch import Tensor, cat
 import torch.nn as nn
@@ -20,32 +20,32 @@ class DEFuncBase(nn.Module):
     def __init__(self, vector_field:Callable, has_time_arg:bool=True):
         """Basic wrapper to ensure call signature compatibility between generic torch Modules and vector fields.
         Args:
-            vector_field (Callable): callable defining the dynamics / vector field / `dxdt` / forcing function 
-            has_time_arg (bool, optional): Internal arg. to indicate whether the callable has `t` in its `__call__' 
+            vector_field (Callable): callable defining the dynamics / vector field / `dxdt` / forcing function
+            has_time_arg (bool, optional): Internal arg. to indicate whether the callable has `t` in its `__call__'
                 or `forward` method. Defaults to True.
         """
         super().__init__()
-        self.nfe, self.vf, self.has_time_arg = 0., vector_field, has_time_arg 
+        self.nfe, self.vf, self.has_time_arg = 0., vector_field, has_time_arg
 
-    def forward(self, t:Tensor, x:Tensor) -> Tensor:
+    def forward(self, t:Tensor, x:Tensor, args:Dict={}) -> Tensor:
         self.nfe += 1
-        if self.has_time_arg: return self.vf(t, x)
+        if self.has_time_arg: return self.vf(t, x, args=args)
         else: return self.vf(x)
 
 
 class DEFunc(nn.Module):
     def __init__(self, vector_field:Callable, order:int=1):
-        """Special vector field wrapper for Neural ODEs. 
-        
+        """Special vector field wrapper for Neural ODEs.
+
         Handles auxiliary tasks: time ("depth") concatenation, higher-order dynamics and forward propagated integral losses.
 
         Args:
-            vector_field (Callable): callable defining the dynamics / vector field / `dxdt` / forcing function 
+            vector_field (Callable): callable defining the dynamics / vector field / `dxdt` / forcing function
             order (int, optional): order of the differential equation. Defaults to 1.
-        
+
         Notes:
             Currently handles the following:
-            (1) assigns time tensor to each submodule requiring it (e.g. `GalLinear`). 
+            (1) assigns time tensor to each submodule requiring it (e.g. `GalLinear`).
             (2) in case of integral losses + reverse-mode differentiation, propagates the loss in the first dimension of `x`
                 and automatically splits the Tensor into `x[:, 0]` and `x[:, 1:]` for vector field computation
             (3) in case of higher-order dynamics, adjusts the vector field forward to recursively compute various orders.
@@ -55,7 +55,7 @@ class DEFunc(nn.Module):
         self.order, self.integral_loss, self.sensitivity = order, None, None
         # identify whether vector field already has time arg
 
-    def forward(self, t:Tensor, x:Tensor) -> Tensor:
+    def forward(self, t:Tensor, x:Tensor, args:Dict={}) -> Tensor:
         self.nfe += 1
         # set `t` depth-variable to DepthCat modules
         for _, module in self.vf.named_modules():
@@ -67,17 +67,17 @@ class DEFunc(nn.Module):
             x_dyn = x[:, 1:]
             dlds = self.integral_loss(t, x_dyn)
             if len(dlds.shape) == 1: dlds = dlds[:, None]
-            if self.order > 1: x_dyn = self.horder_forward(t, x_dyn)
+            if self.order > 1: x_dyn = self.horder_forward(t, x_dyn, args)
             else: x_dyn = self.vf(t, x_dyn)
             return cat([dlds, x_dyn], 1).to(x_dyn)
 
         # regular forward
         else:
             if self.order > 1: x = self.higher_order_forward(t, x)
-            else: x = self.vf(t, x)
+            else: x = self.vf(t, x, args=args)
             return x
 
-    def higher_order_forward(self, t:Tensor, x:Tensor) -> Tensor:
+    def higher_order_forward(self, t:Tensor, x:Tensor, args:Dict={}) -> Tensor:
         x_new = []
         size_order = x.size(1) // self.order
         for i in range(1, self.order):
@@ -85,7 +85,7 @@ class DEFunc(nn.Module):
         x_new.append(self.vf(t, x))
         return cat(x_new, dim=1).to(x)
 
-    
+
 class SDEFunc(nn.Module):
     def __init__(self, f:Callable, g:Callable, order:int=1):
         """"Special vector field wrapper for Neural SDEs.
@@ -95,23 +95,23 @@ class SDEFunc(nn.Module):
             g (Callable): callable defining the diffusion term
             order (int, optional): order of the differential equation. Defaults to 1.
         """
-        super().__init__()  
+        super().__init__()
         self.order, self.intloss, self.sensitivity = order, None, None
         self.f_func, self.g_func = f, g
         self.nfe = 0
 
-    def forward(self, t:Tensor, x:Tensor) -> Tensor:
+    def forward(self, t:Tensor, x:Tensor, args:Dict={}) -> Tensor:
         pass
-    
-    def f(self, t:Tensor, x:Tensor) -> Tensor:
+
+    def f(self, t:Tensor, x:Tensor, args:Dict={}) -> Tensor:
         self.nfe += 1
         for _, module in self.f_func.named_modules():
             if hasattr(module, 't'):
                 module.t = t
-        return self.f_func(x)
-    
-    def g(self, t:Tensor, x:Tensor) -> Tensor:
+        return self.f_func(x, args)
+
+    def g(self, t:Tensor, x:Tensor, args:Dict={}) -> Tensor:
         for _, module in self.g_func.named_modules():
             if hasattr(module, 't'):
                 module.t = t
-        return self.g_func(x)
+        return self.g_func(x, args)

--- a/torchdyn/numerics/systems.py
+++ b/torchdyn/numerics/systems.py
@@ -12,20 +12,20 @@
 
 import torch
 import torch.nn as nn
-import torch.distributions 
+import torch.distributions
 from torch.distributions import Uniform
 
 
 class Lorenz(nn.Module):
     def __init__(self):
         super().__init__()
-        self.p = nn.Linear(1,1)
-    
-    def forward(self, t, x):
-        x1, x2, x3 = x[...,:1], x[...,1:2], x[...,2:]
+        self.p = nn.Linear(1, 1)
+
+    def forward(self, t, x, **kwargs):
+        x1, x2, x3 = x[..., :1], x[..., 1:2], x[..., 2:]
         dx1 = 10 * (x2 - x1)
         dx2 = x1 * (28 - x3) - x2
-        dx3 = x1 * x2 - 8/3 * x3
+        dx3 = x1 * x2 - 8 / 3 * x3
         return torch.cat([dx1, dx2, dx3], -1)
 
 
@@ -35,44 +35,46 @@ class VanDerPol(nn.Module):
         self.alpha = alpha
         self.nfe = 0
 
-    def forward(self, t, x):
+    def forward(self, t, x, **kwargs):
         self.nfe += 1
-        x1, x2 = x[...,:1], x[...,1:2]
-        return torch.cat([x2, self.alpha * (1 - x1**2) * x2 - x1], -1)
-        
+        x1, x2 = x[..., :1], x[..., 1:2]
+        return torch.cat([x2, self.alpha * (1 - x1 ** 2) * x2 - x1], -1)
+
+
 class ODEProblem2(nn.Module):
     def __init__(self):
         super().__init__()
-    
+
     def forward(self, s, z):
-        return 0.5*z
-  
+        return 0.5 * z
+
+
 class ODEProblem3(nn.Module):
     def __init__(self):
         super().__init__()
-    
-    def forward(self, s, z):
-        return -0.1*z
 
-    
+    def forward(self, s, z):
+        return -0.1 * z
+
+
 class ODEProblem4(nn.Module):
     "Rabinovich-Fabrikant"
+
     def __init__(self):
         super().__init__()
-    
-    def forward(self, s, z):
-        x1, x2, x3 = z[...,:1], z[...,1:2], z[...,-1:] 
-        dx1 = x2 * (x3 - 1 + x1**2) + 0.87*x1
-        dx2 = x1*(3*x3+1-x1**2) + 0.87*x2
-        dx3 = -2*x3*(1.1+x1*x2)
-        return torch.cat([dx1, dx2, dx3], -1)
 
+    def forward(self, s, z):
+        x1, x2, x3 = z[..., :1], z[..., 1:2], z[..., -1:]
+        dx1 = x2 * (x3 - 1 + x1 ** 2) + 0.87 * x1
+        dx2 = x1 * (3 * x3 + 1 - x1 ** 2) + 0.87 * x2
+        dx3 = -2 * x3 * (1.1 + x1 * x2)
+        return torch.cat([dx1, dx2, dx3], -1)
 
 
 class SineSystem(nn.Module):
     def __init__(self):
         super().__init__()
-    
+
     def forward(self, s, z):
         s = s * torch.ones_like(z)
         return torch.sin(s)
@@ -84,84 +86,17 @@ class LTISystem(nn.Module):
         self.dim = dim
         self.randomizable = randomizable
         self.l = nn.Linear(dim, dim)
-        
+
     def forward(self, s, x):
-        return self.l(x) 
-    
+        return self.l(x)
+
     def randomize_parameters(self):
         self.l = nn.Linear(self.dim, self.dim)
 
+
 class FourierSystem(nn.Module):
     def __init__(self,
-                 dim=2, 
-                 A_dist=Uniform(-10, 10),
-                 phi_dist=Uniform(-1, 1),
-                 w_dist=Uniform(-20, 20),
-                 randomizable=True
-                 ):
-        
-        super().__init__()
-        self.n_harmonics = n_harmonics = torch.randint(2, 20, size=(1,))
-        self.A_dist = A_dist; self.A = A_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.phi_dist = phi_dist; self.phi = phi_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.w_dist = w_dist; self.w = w_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.dim = dim
-        self.randomizable = randomizable
-        
-    def forward(self, s, x):
-        if len(s.shape) == 0:
-            return (self.A[:, :, 0] * torch.cos(self.w[:, :, 0]*s + self.phi[:, :, 0]) + 
-                   self.A[:, :, 1] * torch.cos(self.w[:, :, 1]*s + self.phi[:, :, 1])).sum(1)[None, :]
-        else:
-            sol = []
-            for s_ in s:
-                sol += [(self.A[:, :, 0] * torch.cos(self.w[:, :, 0]*s_ + self.phi[:, :, 0]) + 
-                   self.A[:, :, 1] * torch.cos(self.w[:, :, 1]*s_ + self.phi[:, :, 1])).sum(1)[None, :]]
-            return torch.cat(sol)
-        
-    def randomize_parameters(self):
-        self.A = self.A_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
-        self.phi = self.phi_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
-        self.w = self.w_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
-        
-        
-class StiffFourierSystem(nn.Module):
-    def __init__(self,
-                 dim=2, 
-                 A_dist=Uniform(-10, 10),
-                 phi_dist=Uniform(-1, 1),
-                 w_dist=Uniform(-20, 20),
-                 randomizable=True
-                 ):
-        
-        super().__init__()
-        self.n_harmonics = n_harmonics = torch.randint(20, 100, size=(1,))
-        self.A_dist = A_dist; self.A = A_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.phi_dist = phi_dist; self.phi = phi_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.w_dist = w_dist; self.w = w_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.dim = dim
-        self.randomizable = randomizable
-        
-    def forward(self, s, x):
-        if len(s.shape) == 0:
-            return (self.A[:, :, 0] * torch.cos(self.w[:, :, 0]*s + self.phi[:, :, 0]) + 
-                   self.A[:, :, 1] * torch.cos(self.w[:, :, 1]*s + self.phi[:, :, 1])).sum(1)[None, :]
-        else:
-            sol = []
-            for s_ in s:
-                sol += [(self.A[:, :, 0] * torch.cos(self.w[:, :, 0]*s_ + self.phi[:, :, 0]) + 
-                   self.A[:, :, 1] * torch.cos(self.w[:, :, 1]*s_ + self.phi[:, :, 1])).sum(1)[None, :]]
-            return torch.cat(sol)
-        
-    def randomize_parameters(self):
-        self.A = self.A_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
-        self.phi = self.phi_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
-        self.w = self.w_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
-         
-        
-class CoupledFourierSystem(nn.Module):
-    def __init__(self,
-                 dim=2, 
+                 dim=2,
                  A_dist=Uniform(-10, 10),
                  phi_dist=Uniform(-1, 1),
                  w_dist=Uniform(-20, 20),
@@ -170,24 +105,101 @@ class CoupledFourierSystem(nn.Module):
 
         super().__init__()
         self.n_harmonics = n_harmonics = torch.randint(2, 20, size=(1,))
-        self.A_dist = A_dist; self.A = A_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.phi_dist = phi_dist; self.phi = phi_dist.sample(torch.Size([dim, n_harmonics, 2]))
-        self.w_dist = w_dist; self.w = w_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.A_dist = A_dist;
+        self.A = A_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.phi_dist = phi_dist;
+        self.phi = phi_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.w_dist = w_dist;
+        self.w = w_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.dim = dim
+        self.randomizable = randomizable
+
+    def forward(self, s, x):
+        if len(s.shape) == 0:
+            return (self.A[:, :, 0] * torch.cos(self.w[:, :, 0] * s + self.phi[:, :, 0]) +
+                    self.A[:, :, 1] * torch.cos(self.w[:, :, 1] * s + self.phi[:, :, 1])).sum(1)[None, :]
+        else:
+            sol = []
+            for s_ in s:
+                sol += [(self.A[:, :, 0] * torch.cos(self.w[:, :, 0] * s_ + self.phi[:, :, 0]) +
+                         self.A[:, :, 1] * torch.cos(self.w[:, :, 1] * s_ + self.phi[:, :, 1])).sum(1)[None, :]]
+            return torch.cat(sol)
+
+    def randomize_parameters(self):
+        self.A = self.A_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
+        self.phi = self.phi_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
+        self.w = self.w_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
+
+
+class StiffFourierSystem(nn.Module):
+    def __init__(self,
+                 dim=2,
+                 A_dist=Uniform(-10, 10),
+                 phi_dist=Uniform(-1, 1),
+                 w_dist=Uniform(-20, 20),
+                 randomizable=True
+                 ):
+
+        super().__init__()
+        self.n_harmonics = n_harmonics = torch.randint(20, 100, size=(1,))
+        self.A_dist = A_dist;
+        self.A = A_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.phi_dist = phi_dist;
+        self.phi = phi_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.w_dist = w_dist;
+        self.w = w_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.dim = dim
+        self.randomizable = randomizable
+
+    def forward(self, s, x):
+        if len(s.shape) == 0:
+            return (self.A[:, :, 0] * torch.cos(self.w[:, :, 0] * s + self.phi[:, :, 0]) +
+                    self.A[:, :, 1] * torch.cos(self.w[:, :, 1] * s + self.phi[:, :, 1])).sum(1)[None, :]
+        else:
+            sol = []
+            for s_ in s:
+                sol += [(self.A[:, :, 0] * torch.cos(self.w[:, :, 0] * s_ + self.phi[:, :, 0]) +
+                         self.A[:, :, 1] * torch.cos(self.w[:, :, 1] * s_ + self.phi[:, :, 1])).sum(1)[None, :]]
+            return torch.cat(sol)
+
+    def randomize_parameters(self):
+        self.A = self.A_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
+        self.phi = self.phi_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
+        self.w = self.w_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
+
+
+class CoupledFourierSystem(nn.Module):
+    def __init__(self,
+                 dim=2,
+                 A_dist=Uniform(-10, 10),
+                 phi_dist=Uniform(-1, 1),
+                 w_dist=Uniform(-20, 20),
+                 randomizable=True
+                 ):
+
+        super().__init__()
+        self.n_harmonics = n_harmonics = torch.randint(2, 20, size=(1,))
+        self.A_dist = A_dist;
+        self.A = A_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.phi_dist = phi_dist;
+        self.phi = phi_dist.sample(torch.Size([dim, n_harmonics, 2]))
+        self.w_dist = w_dist;
+        self.w = w_dist.sample(torch.Size([dim, n_harmonics, 2]))
         self.dim = dim
         self.randomizable = randomizable
         self.mixing_l = nn.Linear(dim, dim)
 
     def forward(self, s, x):
         if len(s.shape) == 0:
-            pre_sol = (self.A[:, :, 0] * torch.cos(self.w[:, :, 0]*s + self.phi[:, :, 0]) + 
-                       self.A[:, :, 1] * torch.cos(self.w[:, :, 1]*s + self.phi[:, :, 1])).sum(1)[None, :]
+            pre_sol = (self.A[:, :, 0] * torch.cos(self.w[:, :, 0] * s + self.phi[:, :, 0]) +
+                       self.A[:, :, 1] * torch.cos(self.w[:, :, 1] * s + self.phi[:, :, 1])).sum(1)[None, :]
             return self.mixing_l(pre_sol)
 
         else:
             sol = []
             for s_ in s:
-                sol += [(self.A[:, :, 0] * torch.cos(self.w[:, :, 0]*s_ + self.phi[:, :, 0]) + 
-                   self.A[:, :, 1] * torch.cos(self.w[:, :, 1]*s_ + self.phi[:, :, 1])).sum(1)[None, None, :]]
+                sol += [(self.A[:, :, 0] * torch.cos(self.w[:, :, 0] * s_ + self.phi[:, :, 0]) +
+                         self.A[:, :, 1] * torch.cos(self.w[:, :, 1] * s_ + self.phi[:, :, 1])).sum(1)[None, None, :]]
             return self.mixing_l(torch.cat(sol, 0))[:, 0, :]
 
     def randomize_parameters(self):
@@ -196,16 +208,16 @@ class CoupledFourierSystem(nn.Module):
         self.w = self.w_dist.sample(torch.Size([self.dim, self.n_harmonics, 2]))
         self.mixing_l = nn.Linear(self.dim, self.dim)
 
-        
+
 class MatMulSystem(nn.Module):
     def __init__(self, dim=2, activation=nn.Tanh(), layers=5, hdim=32, randomizable=True):
         super().__init__()
         self.dim = dim
-        self.net = nn.Sequential(nn.Sequential(nn.Linear(dim, hdim), nn.Tanh(), 
-                                 *[nn.Sequential(nn.Linear(hdim, hdim), nn.Tanh()) for i in range(4)], 
-                                 nn.Linear(hdim, dim)))
+        self.net = nn.Sequential(nn.Sequential(nn.Linear(dim, hdim), nn.Tanh(),
+                                               *[nn.Sequential(nn.Linear(hdim, hdim), nn.Tanh()) for i in range(4)],
+                                               nn.Linear(hdim, dim)))
         self.randomizable = randomizable
-        
+
     def forward(self, s, x):
         return self.net(x)
 
@@ -213,22 +225,21 @@ class MatMulSystem(nn.Module):
         for p in self.net.parameters():
             torch.nn.init.normal_(p, 0, 1)
 
-            
+
 class MatMulBoundedSystem(nn.Module):
     def __init__(self, dim=2, activation=nn.Tanh(), layers=5, hdim=32, randomizable=True):
         super().__init__()
         self.dim = dim
-        self.net = nn.Sequential(nn.Sequential(nn.Linear(dim, hdim), nn.Tanh(), 
-                                 *[nn.Sequential(nn.Linear(hdim, hdim), nn.Tanh()) for i in range(4)], 
-                                 nn.Linear(hdim, dim), 
-                                 nn.Tanh()))
+        self.net = nn.Sequential(nn.Sequential(nn.Linear(dim, hdim), nn.Tanh(),
+                                               *[nn.Sequential(nn.Linear(hdim, hdim), nn.Tanh()) for i in range(4)],
+                                               nn.Linear(hdim, dim),
+                                               nn.Tanh()))
         self.randomizable = randomizable
-        
+
     def forward(self, s, x):
-        return self.net(x) 
-    
+        return self.net(x)
+
     def randomize_parameters(self):
         for p in self.net.parameters():
             torch.nn.init.normal_(p, 0, 1)
 
-          


### PR DESCRIPTION
You have to pass it everywhere that you pass (t, x)

It would be good to just take `**kwargs` like pytorch does