### PR TITLE
Error control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,15 @@ build-backend = "poetry.masonry.api"
 requires = ["poetry", "wheel", "setuptools-cpp"]
 
 [tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "CRITICAL"
+log_cli_format = "%(message)s"
+
+log_file = "pytest.log"
+log_file_level = "DEBUG"
+log_file_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_file_date_format = "%Y-%m-%d %H:%M:%S"
+
 filterwarnings = [
         "ignore:Call to deprecated create function FieldDescriptor",  # pytorch lightning needs tensorboard which has a conflict with python 3.9
         "ignore:Call to deprecated create function Descriptor", # pytorch lightning needs tensorboard which has a conflict with python 3.9

--- a/test/test_sensitivity.py
+++ b/test/test_sensitivity.py
@@ -45,8 +45,9 @@ def test_odeint_adjoint(sensitivity, solver, interpolator, stiffness):
 
     f = VanDerPol(stiffness)
     x = torch.randn(1024, 2, requires_grad=True)
-    t0 = time.time()
+    
     prob = ODEProblem(f, sensitivity=sensitivity, interpolator=interpolator, solver=solver, atol=1e-4, rtol=1e-4, atol_adjoint=1e-4, rtol_adjoint=1e-4)
+    t0 = time.time()
     t_eval, sol_torchdyn = prob.odeint(x, t_span)
     t_end1 = time.time() - t0
 

--- a/torchdyn/numerics/solvers/ode.py
+++ b/torchdyn/numerics/solvers/ode.py
@@ -152,7 +152,7 @@ class DormandPrince45(DiffEqSolver):
         k6 = f(t + c[4] * dt, x + dt * a[4][0] * k1 + dt * a[4][1] * k2 + dt * a[4][2] * k3 + dt * a[4][3] * k4 + dt * a[4][4] * k5)
         k7 = f(t + c[5] * dt, x + dt * a[5][0] * k1 + dt * a[5][1] * k2 + dt * a[5][2] * k3 + dt * a[5][3] * k4 + dt * a[5][4] * k5 + dt * a[5][5] * k6)
         x_sol = x + dt * (bsol[0] * k1 + bsol[1] * k2 + bsol[2] * k3 + bsol[3] * k4 + bsol[4] * k5 + bsol[5] * k6)
-        err = berr[0] * k1 + berr[1] * k2 + berr[2] * k3 + berr[3] * k4 + berr[4] * k5 + berr[5] * k6 + berr[6] * k7
+        err = dt * (berr[0] * k1 + berr[1] * k2 + berr[2] * k3 + berr[3] * k4 + berr[4] * k5 + berr[5] * k6 + berr[6] * k7)
         return k7, x_sol, err, (k1, k2, k3, k4, k5, k6, k7)
 
 
@@ -174,7 +174,7 @@ class Tsitouras45(DiffEqSolver):
         k6 = f(t + c[4] * dt, x + dt * a[4][0] * k1 + dt * a[4][1] * k2 + dt * a[4][2] * k3 + dt * a[4][3] * k4 + dt * a[4][4] * k5)
         k7 = f(t + c[5] * dt, x + dt * a[5][0] * k1 + dt * a[5][1] * k2 + dt * a[5][2] * k3 + dt * a[5][3] * k4 + dt * a[5][4] * k5 + dt * a[5][5] * k6)
         x_sol = x + dt * (bsol[0] * k1 + bsol[1] * k2 + bsol[2] * k3 + bsol[3] * k4 + bsol[4] * k5 + bsol[5] * k6)
-        err = berr[0] * k1 + berr[1] * k2 + berr[2] * k3 + berr[3] * k4 + berr[4] * k5 + berr[5] * k6 + berr[6] * k7
+        err = dt * (berr[0] * k1 + berr[1] * k2 + berr[2] * k3 + berr[3] * k4 + berr[4] * k5 + berr[5] * k6 + berr[6] * k7)
         return k7, x_sol, err, (k1, k2, k3, k4, k5, k6, k7)
 
 


### PR DESCRIPTION
Resolves #164.

Slightly faster than before (left, `torchdyn`, right `torchdiffeq` for `test_sensitivity.py` configurations):

```
2022-08-22 06:38:59 [    INFO] Fwd times: 0.065, 0.008 (test_sensitivity.py:58)
2022-08-22 06:38:59 [    INFO] Bwd times: 0.231, 0.330 (test_sensitivity.py:70)
2022-08-22 06:39:00 [    INFO] Fwd times: 0.063, 0.008 (test_sensitivity.py:58)
2022-08-22 06:39:01 [    INFO] Bwd times: 0.283, 0.327 (test_sensitivity.py:70)
2022-08-22 06:39:01 [    INFO] Fwd times: 0.063, 0.008 (test_sensitivity.py:58)
2022-08-22 06:39:02 [    INFO] Bwd times: 0.222, 0.327 (test_sensitivity.py:70)
2022-08-22 06:39:02 [    INFO] Fwd times: 0.063, 0.008 (test_sensitivity.py:58)
2022-08-22 06:39:03 [    INFO] Bwd times: 0.284, 0.326 (test_sensitivity.py:70)
2022-08-22 06:39:04 [    INFO] Fwd times: 0.063, 0.009 (test_sensitivity.py:58)
2022-08-22 06:39:04 [    INFO] Bwd times: 0.221, 0.327 (test_sensitivity.py:70)
2022-08-22 06:39:05 [    INFO] Fwd times: 0.063, 0.009 (test_sensitivity.py:58)
2022-08-22 06:39:05 [    INFO] Bwd times: 0.282, 0.326 (test_sensitivity.py:70)
2022-08-22 06:39:06 [    INFO] Fwd times: 0.063, 0.011 (test_sensitivity.py:58)
2022-08-22 06:39:07 [    INFO] Bwd times: 0.221, 0.326 (test_sensitivity.py:70)
2022-08-22 06:39:07 [    INFO] Fwd times: 0.063, 0.010 (test_sensitivity.py:58)
2022-08-22 06:39:08 [    INFO] Bwd times: 0.283, 0.327 (test_sensitivity.py:70)
```