### PR TITLE
Fix complex-valued `t_span` for complex-valued ODEs in odeint

### DIFF
--- a/torchdyn/numerics/sensitivity.py
+++ b/torchdyn/numerics/sensitivity.py
@@ -62,7 +62,7 @@ def _gather_odefunc_adjoint(vf, vf_params, solver, atol, rtol, interpolator, sol
                     x, t = x.requires_grad_(True), t.requires_grad_(True)
                     dx = vf(t, x)
                     dλ, dt, *dμ = tuple(grad(dx, (x, t) + tuple(vf.parameters()), -λ,
-                                    allow_unused=True, retain_graph=False))
+                                    allow_unused=True, retain_graph=True))
 
                     if integral_loss:
                         dg = torch.autograd.grad(integral_loss(t, x).sum(), x, allow_unused=True, retain_graph=True)[0]

--- a/torchdyn/numerics/sensitivity.py
+++ b/torchdyn/numerics/sensitivity.py
@@ -89,7 +89,7 @@ def _gather_odefunc_adjoint(vf, vf_params, solver, atol, rtol, interpolator, sol
                 A[-1, -1:] -= grad_output[0][i - 1]
                 dLdt[i-1] = dLdt_
 
-                A = torch.cat([A[-1, :xT_nel], A[-1, xT_nel:xT_nel + λT_nel], A[-1, -μT_nel-1:-1], A[-1, -1:]])
+                A = torch.cat([sol[i-1].flatten(), A[-1, xT_nel:xT_nel + λT_nel], A[-1, -μT_nel-1:-1], A[-1, -1:]])
                 A[xT_nel:xT_nel + λT_nel] += grad_output[-1][i - 1].flatten()
 
             λ, μ = A[xT_nel:xT_nel + λT_nel], A[-μT_nel-1:-1]

--- a/torchdyn/numerics/solvers/_constants.py
+++ b/torchdyn/numerics/solvers/_constants.py
@@ -18,7 +18,8 @@ ExplicitRKTableau = namedtuple('ExplicitRKTableau', 'c, A, b_sol, b_err')
 
 
 def construct_rk4(dtype):
-    c = torch.tensor([0., 1 / 2, 1 / 2, 1], dtype=dtype)
+    t_dtype = getattr(torch, torch.finfo(dtype).dtype)
+    c = torch.tensor([0., 1 / 2, 1 / 2, 1], dtype=t_dtype)
     a = [
         torch.tensor([1 / 2], dtype=dtype),
         torch.tensor([0., 1 / 2], dtype=dtype),
@@ -29,7 +30,8 @@ def construct_rk4(dtype):
 
 
 def construct_dopri5(dtype):
-    c = torch.tensor([1 / 5, 3 / 10, 4 / 5, 8 / 9, 1., 1.], dtype=dtype)
+    t_dtype = getattr(torch, torch.finfo(dtype).dtype)
+    c = torch.tensor([1 / 5, 3 / 10, 4 / 5, 8 / 9, 1., 1.], dtype=t_dtype)
     a = [
         torch.tensor([1 / 5], dtype=dtype),
         torch.tensor([3 / 40, 9 / 40], dtype=dtype),
@@ -47,7 +49,7 @@ def construct_dopri5(dtype):
 
 
 def construct_tsit5(dtype):
-
+    t_dtype = getattr(torch, torch.finfo(dtype).dtype)
     c = torch.tensor([
         161 / 1000,
         327 / 1000,
@@ -55,7 +57,7 @@ def construct_tsit5(dtype):
         .9800255409045096857298102862870245954942137979563024768854764293221195950761080302604,
         1.,
         1.
-    ], dtype=dtype)
+    ], dtype=t_dtype)
     a = [
         torch.tensor([
             161 / 1000

--- a/torchdyn/numerics/solvers/ode.py
+++ b/torchdyn/numerics/solvers/ode.py
@@ -44,10 +44,11 @@ class SolverTemplate(nn.Module):
             raise NotImplementedError(f"{type(x)} is not supported as the state variable")
 
         device = proto_arr.device
-
+        t_dtype = getattr(torch, torch.finfo(proto_arr.dtype).dtype)
+        
         if self.tableau is not None:
             c, a, bsol, berr = self.tableau
-            self.tableau = c.to(proto_arr), [a.to(proto_arr) for a in a], bsol.to(proto_arr), berr.to(proto_arr)
+            self.tableau = c.to(device, t_dtype), [a.to(proto_arr) for a in a], bsol.to(proto_arr), berr.to(proto_arr)
         t_span = t_span.to(device)
         self.safety = self.safety.to(device)
         self.min_factor = self.min_factor.to(device)

--- a/torchdyn/numerics/solvers/templates.py
+++ b/torchdyn/numerics/solvers/templates.py
@@ -30,9 +30,10 @@ class DiffEqSolver(nn.Module):
     def sync_device_dtype(self, x, t_span):
         "Ensures `x`, `t_span`, `tableau` and other solver tensors are on the same device with compatible dtypes"
         device = x.device
+        t_dtype = getattr(torch, torch.finfo(x.dtype).dtype)
         if self.tableau is not None:
             c, a, bsol, berr = self.tableau
-            self.tableau = c.to(x), [a.to(x) for a in a], bsol.to(x), berr.to(x)
+            self.tableau = c.to(device, t_dtype), [a.to(x) for a in a], bsol.to(x), berr.to(x)
         t_span = t_span.to(device)
         self.safety = self.safety.to(device)
         self.min_factor = self.min_factor.to(device)


### PR DESCRIPTION
Following up on my PR https://github.com/DiffEqML/torchdyn/pull/178 and on this issue https://github.com/DiffEqML/torchdyn/issues/177. 

In the current state of `odeint`, the time values `t` are complex-valued if `x` is initially complex-valued when calling `f(t, x)` at every time step. Instead, they should be float like. Otherwise, this could be problematic if `f(t, x)` requires real-valued times (e.g. if `f(t, x) = torch.erf(t) * x`).

This PR fixes this by making changes to the `solver.tableau` definitions. The `c` constants in the tableaus are initialized with a float dtype of the same precision as the (complex or float) dtype of `x`. This is done by calling `t_dtype = getattr(torch, torch.finfo(x.dtype).dtype)`. If `x` is float-valued, then `t_dtype = x.dtype` and things work as usual. Changes in `sync_device_dtype` were also required to differentiate between the `t.dtype` and the `x.dtype`.

Sorry for having missed this in the initial PR !