### PR TITLE
explicit package definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,5 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
     ],
+    packages=["torchdyn"],
 )


### PR DESCRIPTION
Added `torchdyn` explicitly to `setup.py` in order for pip install to correctly handle installation.

I would propose a follow up PR where `pyproject.toml` is changed from depending to poetry to setuptools, and removing `setup.py` entirely, so there is only a single build for the project to manage.

Specifically, I am referring to using the `setuptools` build system, as seen [here](https://github.com/saleml/torchgfn/blob/generic-gfn/pyproject.toml).

But I will only do this if the maintainers agree it is worthwhile.