### PR TITLE
Minor typo in quickstart.ipynb

### DIFF
--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -216,7 +216,7 @@
     "    \n",
     "    def training_step(self, batch, batch_idx):\n",
     "        x, y = batch      \n",
-    "        t_eval, y_hat = self.model(x, t_span)\n",
+    "        t_eval, y_hat = self.model(x, self.t_span)\n",
     "        y_hat = y_hat[-1] # select last point of solution trajectory\n",
     "        loss = nn.CrossEntropyLoss()(y_hat, y)\n",
     "        return {'loss': loss}   \n",


### PR DESCRIPTION
In the first example, `t_span` in the lightning module should be `self.t_span`

t_span -> self.t_span