### PR TITLE
Quickstrat desc possible mistake?

### DIFF
--- a/docs/tutorials/quickstart.ipynb
+++ b/docs/tutorials/quickstart.ipynb
@@ -278,7 +278,7 @@
     "\n",
     "by just specifying a neural network $f$ and giving some simple settings.\n",
     "\n",
-    "**Note:** This Neural ODE model is of *depth-invariant* type as neither $f$ explicitly depend on $s$ nor the parameters $\\theta$ are depth-varying. Together with their *depth-variant* counterpart with $s$ concatenated in the vector field was first proposed and implemented by [[Chen T. Q. et al, 2018]](https://arxiv.org/abs/1806.07366)"
+    "**Note:** This Neural ODE model is of *depth-invariant* type as neither $f$ explicitly depend on $t$ nor the parameters $\\theta$ are depth-varying. Together with their *depth-variant* counterpart with $s$ concatenated in the vector field was first proposed and implemented by [[Chen T. Q. et al, 2018]](https://arxiv.org/abs/1806.07366)"
    ],
    "metadata": {
     "papermill": {

--- a/tutorials/00_quickstart.ipynb
+++ b/tutorials/00_quickstart.ipynb
@@ -300,7 +300,7 @@
     "\n",
     "by just specifying a neural network $f$ and giving some simple settings.\n",
     "\n",
-    "**Note:** This Neural ODE model is of *depth-invariant* type as neither $f$ explicitly depend on $s$ nor the parameters $\\theta$ are depth-varying. Together with their *depth-variant* counterpart with $s$ concatenated in the vector field was first proposed and implemented by [[Chen T. Q. et al, 2018]](https://arxiv.org/abs/1806.07366)"
+    "**Note:** This Neural ODE model is of *depth-invariant* type as neither $f$ explicitly depend on $t$ nor the parameters $\\theta$ are depth-varying. Together with their *depth-variant* counterpart with $s$ concatenated in the vector field was first proposed and implemented by [[Chen T. Q. et al, 2018]](https://arxiv.org/abs/1806.07366)"
    ]
   },
   {


### PR DESCRIPTION
Fairly new to NeuralODE, but from what I can gather a depth-invariant NeuralODE do not depend explicitly on time and not the state. So I changed the definition of depth-invariant NeuralODE from:

"This Neural ODE model is of depth-invariant type as neither f explicitly depend on **s** nor the parameters..." to "This Neural ODE model is of depth-invariant type as neither f explicitly depend on **t** nor the parameters..."

in the quickstart tutorial

Lmk if I messed up :]