### PR TITLE
Code Improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,6 @@ filterwarnings = [
         "ignore:Call to deprecated create function EnumValueDescriptor", # pytorch lightning needs tensorboard which has a conflict with python 3.9
         "ignore:Call to deprecated create function FileDescriptor", # pytorch lightning needs tensorboard which has a conflict with python 3.9
         "ignore:Call to deprecated create function OneofDescriptor", # pytorch lightning needs tensorboard which has a conflict with python 3.9
+        "ignore:.+does not have many workers which may be a bottleneck",
+        "ignore:The number of training batches"
     ]

--- a/test/models/test_ode.py
+++ b/test/models/test_ode.py
@@ -39,7 +39,7 @@ t_span = torch.linspace(0, 1, 30)
 
 def test_repr(small_mlp):
     model = NeuralODE(small_mlp)
-    assert type(model.__repr__()) == str and 'NFE' in model.__repr__()
+    assert isinstance(model.__repr__(), str) and 'NFE' in model.__repr__()
 
 
 # TODO: extend to GPU and Multi-GPU
@@ -105,14 +105,14 @@ def test_deepcopy(small_mlp, device):
     model = NeuralODE(small_mlp)
     x = torch.rand(1, 2)
     copy_before_forward = copy.deepcopy(model)
-    assert type(copy_before_forward) == NeuralODE
+    assert isinstance(copy_before_forward, NeuralODE)
 
     # do a forward+backward pass
     y = model(x)
     loss = y.sum()
     loss.backward()
     copy_after_forward = copy.deepcopy(model)
-    assert type(copy_after_forward) == NeuralODE
+    assert isinstance(copy_after_forward, NeuralODE)
 
 
 @pytest.mark.skip(reason='clean up to new API')

--- a/torchdyn/core/neuralde.py
+++ b/torchdyn/core/neuralde.py
@@ -23,8 +23,6 @@ from torch import Tensor
 import torch.nn as nn
 import torchsde
 
-import warnings
-
 
 class NeuralODE(ODEProblem, pl.LightningModule):
     def __init__(
@@ -51,12 +49,12 @@ class NeuralODE(ODEProblem, pl.LightningModule):
                                        In the second case, the Callable is automatically wrapped for consistency
             solver (Union[str, nn.Module]): 
             order (int, optional): Order of the ODE. Defaults to 1.
-            atol (float, optional): Absolute tolerance of the solver. Defaults to 1e-4.
-            rtol (float, optional): Relative tolerance of the solver. Defaults to 1e-4.
+            atol (float, optional): Absolute tolerance of the solver. Defaults to 1e-3.
+            rtol (float, optional): Relative tolerance of the solver. Defaults to 1e-3.
             sensitivity (str, optional): Sensitivity method ['autograd', 'adjoint', 'interpolated_adjoint']. Defaults to 'autograd'.
             solver_adjoint (Union[str, nn.Module, None], optional): ODE solver for the adjoint. Defaults to None.
-            atol_adjoint (float, optional): Defaults to 1e-6.
-            rtol_adjoint (float, optional): Defaults to 1e-6.
+            atol_adjoint (float, optional): Defaults to 1e-4.
+            rtol_adjoint (float, optional): Defaults to 1e-4.
             integral_loss (Union[Callable, None], optional): Defaults to None.
             seminorm (bool, optional): Whether to use seminorms for adaptive stepping in backsolve adjoints. Defaults to False.
             return_t_eval (bool): Whether to return (t_eval, sol) or only sol. Useful for chaining NeuralODEs in `nn.Sequential`.
@@ -171,15 +169,6 @@ class NeuralSDE(SDEProblem, pl.LightningModule):
         bm=None,
         return_t_eval: bool = True,
     ):
-        super().__init__(
-            defunc=SDEFunc(f=drift_func, g=diffusion_func, order=order),
-            solver=solver,
-            interpolator=interpolator,
-            atol=atol,
-            rtol=rtol,
-            sensitivity=sensitivity,
-        )
-
         """Generic Neural Stochastic Differential Equation. Follows the same design of the `NeuralODE` class.
 
         Args:
@@ -204,6 +193,15 @@ class NeuralSDE(SDEProblem, pl.LightningModule):
         Notes:
             The current implementation is rougher around the edges compared to `NeuralODE`, and is not guaranteed to have the same features.
         """
+        super().__init__(
+            defunc=SDEFunc(f=drift_func, g=diffusion_func, order=order),
+            solver=solver,
+            interpolator=interpolator,
+            atol=atol,
+            rtol=rtol,
+            sensitivity=sensitivity,
+        )
+
         if order != 1:
             raise NotImplementedError
         self.defunc.noise_type, self.defunc.sde_type = noise_type, sde_type

--- a/torchdyn/core/problems.py
+++ b/torchdyn/core/problems.py
@@ -8,7 +8,7 @@ from torchdyn.numerics.sensitivity import (
     _gather_odefunc_interp_adjoint,
 )
 from torchdyn.numerics.odeint import odeint, odeint_mshooting
-from torchdyn.numerics.solvers.ode import str_to_solver, str_to_ms_solver
+from torchdyn.numerics.solvers.ode import str_to_solver
 from torchdyn.core.utils import standardize_vf_call_signature
 from torchdyn.core.defunc import SDEFunc
 from torchdyn.numerics import sdeint

--- a/torchdyn/core/problems.py
+++ b/torchdyn/core/problems.py
@@ -53,7 +53,7 @@ class ODEProblem(nn.Module):
         """
         super().__init__()
         # instantiate solver at initialization
-        if type(solver) == str:
+        if isinstance(solver, str):
             solver = str_to_solver(solver)
         if solver_adjoint is None:
             solver_adjoint = solver

--- a/torchdyn/models/hybrid.py
+++ b/torchdyn/models/hybrid.py
@@ -34,7 +34,7 @@ class HybridNeuralDE(nn.Module):
         # either take hidden and element of sequence (e.g RNNCell)
         # or h, x_t and c (LSTMCell). Custom implementation assumes call
         # signature of type (x_t, h) and .hidden_size property
-        if type(jump) == nn.modules.rnn.LSTMCell:
+        if isinstance(jump, nn.modules.rnn.LSTMCell):
             self.jump_func = self._jump_latent_cell
         else:
             self.jump_func = self._jump_latent

--- a/torchdyn/numerics/sdeint.py
+++ b/torchdyn/numerics/sdeint.py
@@ -49,10 +49,10 @@ def sdeint(
     # make sde to SDEFunc form?
     sde = check_sde(sde)
 
-    if type(t_span) == list:
+    if isinstance(t_span, list):
         t_span = torch.cat(t_span)
 
-    if type(solver) == str:
+    if isinstance(solver, str):
         solver = sde_str_to_solver(solver, sde, bm, x.dtype)
     x, t_span = solver.sync_device_dtype(x, t_span)
     stepping_class = solver.stepping_class

--- a/torchdyn/numerics/solvers/templates.py
+++ b/torchdyn/numerics/solvers/templates.py
@@ -69,8 +69,10 @@ class MultipleShootingDiffeqSolver(nn.Module):
         from torchdyn.numerics.solvers.ode import str_to_solver
 
         super(MultipleShootingDiffeqSolver, self).__init__()
-        if type(coarse_method) == str: self.coarse_method = str_to_solver(coarse_method)
-        if type(fine_method) == str: self.fine_method = str_to_solver(fine_method)
+        if isinstance(coarse_method, str):
+            self.coarse_method = str_to_solver(coarse_method)
+        if isinstance(fine_method, str):
+            self.fine_method = str_to_solver(fine_method)
 
     def sync_device_dtype(self, x, t_span):
         "Ensures `x`, `t_span`, `tableau` and other solver tensors are on the same device with compatible dtypes"


### PR DESCRIPTION
- Fix docstrings for `atol` and `rtol`.
- Use `isinstance` instead of `type(x) == t`.
- Reorder code to reduce warnings.

Additionally, should we remove the warning about fixed step methods not being affected by tolerance values? We can instead put that in the docstring and not pollute the user output space.